### PR TITLE
Added the ability to define Proxy and ProxySSL directives in the EZproxy config.txt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,12 @@
 # [*service_enable*]
 #   Boolean for whether or not to start ezproxy on restart.
 #
+# [*http_proxy*]
+# String for forward proxy configuration for http proxy_hostname:port
+#
+# [*https_proxy*]
+# String for forward proxy configuration for https proxy_hostname:port
+#
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -143,6 +149,8 @@ class ezproxy (
   $service_name             = $::ezproxy::params::service_name,
   $service_status           = $::ezproxy::params::service_status,
   $service_enable           = $::ezproxy::params::service_enable,
+  $http_proxy               = $::ezproxy::params::http_proxy,
+  $https_proxy              = $::ezproxy::params::https_proxy,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)
@@ -212,6 +220,8 @@ class ezproxy (
   validate_string($service_name)
   validate_re($service_status, [ '^running', '^stopped' ])
   validate_bool($service_enable)
+  validate_string($http_proxy)
+  validate_string($https_proxy)
 
   class { '::ezproxy::install': } ->
   class { '::ezproxy::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,8 @@ class ezproxy::params {
   $service_status           = running
   $service_enable           = true
   $service_name             = 'ezproxy'
+  $http_proxy               = undef
+  $https_proxy              = undef
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -119,6 +119,20 @@ LogFilter <%= this_log_filter %>
 LogFile <%= @log_file %>
 LogFormat <%= @log_format %>
 
+## Enable forward proxying to allow EZproxy to access external resources
+## when behind a corporate firewall with no direct access allowed, see
+## https://www.oclc.org/support/services/ezproxy/documentation/cfg/proxy.en.html
+
+<% if @http_proxy -%>
+# Proxy host: port username: password 
+Proxy <%= @http_proxy %>
+<% end -%>
+
+<% if @https_proxy -%>
+# ProxySSL host: port username: password 
+ProxySSL <%= @https_proxy %>
+<% end -%>
+
 # **************************** Database Definitions *****************************************
 ##  See http://www.oclc.org/support/documentation/ezproxy/db/default.htm
 


### PR DESCRIPTION
Added the ability to define Proxy and ProxySSL directives in the EZproxy config.txt, this allows EZProxy to operate when behind a corporate firewall without HTTP/HTTPS allowances.
