### PR TITLE
Added LogUser option, which must not be used with LogSession

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,11 @@
 # [*service_enable*]
 #   Boolean for whether or not to start ezproxy on restart.
 #
+# [*log_user*]
+#   Boolean for whether or not logging of username should be done. This disables
+#   logging of session, if you require both then %{ezproxy-session} can be included
+#   in the log_format parameter
+# 
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -143,6 +148,7 @@ class ezproxy (
   $service_name             = $::ezproxy::params::service_name,
   $service_status           = $::ezproxy::params::service_status,
   $service_enable           = $::ezproxy::params::service_enable,
+  $log_user                 = $::ezproxy::params::log_user,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)
@@ -212,6 +218,7 @@ class ezproxy (
   validate_string($service_name)
   validate_re($service_status, [ '^running', '^stopped' ])
   validate_bool($service_enable)
+  validate_bool($log_user)
 
   class { '::ezproxy::install': } ->
   class { '::ezproxy::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class ezproxy::params {
   $service_status           = running
   $service_enable           = true
   $service_name             = 'ezproxy'
+  $log_user                 = false
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -103,7 +103,16 @@ Option SafariCookiePatch
 Audit Most
 AuditPurge 7
 Option StatusUser
+
+<% if @log_user -%>
+## If LogUser is required then LogSession should not also be included
+## if session identifiers are also required then a custom log format
+## should be specified that includes %{ezproxy-session}
+Option LogUser
+<% else -%>
 Option LogSession
+<% end -%>
+
 IntruderIPAttempts -interval=5 -expires=15 20
 IntruderUserAttempts -interval=5 -expires=15 10
 UsageLimit -enforce -interval=15 -expires=120 -MB=200 Global


### PR DESCRIPTION
Option LogSession specifies that the username provided while logging into EZproxy should be substituted for %u in log formats specified with the LogFormat or LogSPU directives. By including this option in config.txt, your web server log analysis software may be able to link together all of the requests placed by a given user across all EZproxy sessions.

If Option LogSession and Option LogUser both appear in config.txt, then Option LogSession takes priority and prevents Option LogUser from having any effect.

If you want to record both the login username and the session identifier, use Option LogUser to allow %u to be recorded as the username, and %{ezproxy-session}i to record the session identifier.

Taken from the [reference manual](https://www.oclc.org/content/dam/support/ezproxy/documentation/pdf/ezproxy_referencemanual.pdf)
