### PR TITLE
add support for multiple include files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,9 @@
 # [*default_stanzas*]
 #   Boolean for whether or not to include the default databases from OCLC.
 #
+# [*include_files*]
+#   Array of files to include in config.txt
+#
 # [*remote_configs*]
 #   Hash of remote config stanzas to include.
 #   More info in manifests/remote_config.pp.
@@ -137,6 +140,7 @@ class ezproxy (
   $ldap_options             = $::ezproxy::params::ldap_options,
   $ldap_url                 = $::ezproxy::params::ldap_url,
   $default_stanzas          = $::ezproxy::params::default_stanzas,
+  $include_files            = $::ezproxy::params::include_files,
   $remote_configs           = $::ezproxy::params::remote_configs,
   $stanzas                  = $::ezproxy::params::stanzas,
   $manage_service           = $::ezproxy::params::manage_service,
@@ -206,6 +210,7 @@ class ezproxy (
     }
   }
   validate_bool($default_stanzas)
+  validate_array($include_files)
   validate_hash($stanzas)
   validate_hash($remote_configs)
   validate_bool($manage_service)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class ezproxy::params {
   $ldap_options             = []
   $ldap_url                 = undef
   $default_stanzas          = true
-  $include_files            = undef
+  $include_files            = []
   $stanzas                  = {}
   $remote_configs           = {}
   $manage_service           = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class ezproxy::params {
   $ldap_options             = []
   $ldap_url                 = undef
   $default_stanzas          = true
+  $include_files            = undef
   $stanzas                  = {}
   $remote_configs           = {}
   $manage_service           = true

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -123,3 +123,8 @@ LogFormat <%= @log_format %>
 ##  See http://www.oclc.org/support/documentation/ezproxy/db/default.htm
 
 IncludeFile sites.txt
+<% if @include_files -%>
+<% @include_files.each do |this_include_file| -%>
+IncludeFile <%= this_include_file %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Leave the "IncludeFile sites.txt" directive currently included in the puppet-ezproxy module but allow for multiple other IncludeFile lines.
