### PR TITLE
Prepends stanza

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,12 @@
 # [*service_enable*]
 #   Boolean for whether or not to start ezproxy on restart.
 #
+# [*http_proxy*]
+# String for forward proxy configuration for http proxy_hostname:port
+#
+# [*https_proxy*]
+# String for forward proxy configuration for https proxy_hostname:port
+#
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -143,6 +149,8 @@ class ezproxy (
   $service_name             = $::ezproxy::params::service_name,
   $service_status           = $::ezproxy::params::service_status,
   $service_enable           = $::ezproxy::params::service_enable,
+  $http_proxy               = $::ezproxy::params::http_proxy,
+  $https_proxy              = $::ezproxy::params::https_proxy,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)
@@ -212,6 +220,8 @@ class ezproxy (
   validate_string($service_name)
   validate_re($service_status, [ '^running', '^stopped' ])
   validate_bool($service_enable)
+  validate_string($http_proxy)
+  validate_string($https_proxy)
 
   class { '::ezproxy::install': } ->
   class { '::ezproxy::config': } ~>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,11 @@
 # [*service_enable*]
 #   Boolean for whether or not to start ezproxy on restart.
 #
+# [*log_user*]
+#   Boolean for whether or not logging of username should be done. This disables
+#   logging of session, if you require both then %{ezproxy-session} can be included
+#   in the log_format parameter
+# 
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -143,6 +148,7 @@ class ezproxy (
   $service_name             = $::ezproxy::params::service_name,
   $service_status           = $::ezproxy::params::service_status,
   $service_enable           = $::ezproxy::params::service_enable,
+  $log_user                 = $::ezproxy::params::log_user,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)
@@ -212,6 +218,7 @@ class ezproxy (
   validate_string($service_name)
   validate_re($service_status, [ '^running', '^stopped' ])
   validate_bool($service_enable)
+  validate_bool($log_user)
 
   class { '::ezproxy::install': } ->
   class { '::ezproxy::config': } ~>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@
 # String for forward proxy configuration for https proxy_hostname:port
 #
 # [*login_cookie_name*]
-# String for alternate cookie name for EZproxy session cookies
+# String for alternate cookie name for EZproxy session cookie
 #
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,12 +152,9 @@ class ezproxy (
   $service_name             = $::ezproxy::params::service_name,
   $service_status           = $::ezproxy::params::service_status,
   $service_enable           = $::ezproxy::params::service_enable,
-<<<<<<< HEAD
   $http_proxy               = $::ezproxy::params::http_proxy,
   $https_proxy              = $::ezproxy::params::https_proxy,
-=======
   $login_cookie_name        = $::ezproxy::params::login_cookie_name,
->>>>>>> LoginCookieName
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)
@@ -227,12 +224,9 @@ class ezproxy (
   validate_string($service_name)
   validate_re($service_status, [ '^running', '^stopped' ])
   validate_bool($service_enable)
-<<<<<<< HEAD
   validate_string($http_proxy)
   validate_string($https_proxy)
-=======
   validate_string($login_cookie_name)
->>>>>>> LoginCookieName
 
   class { '::ezproxy::install': } ->
   class { '::ezproxy::config': } ~>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,6 +112,9 @@
 # [*https_proxy*]
 # String for forward proxy configuration for https proxy_hostname:port
 #
+# [*login_cookie_name*]
+# String for alternate cookie name for EZproxy session cookies
+#
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -151,6 +154,7 @@ class ezproxy (
   $service_enable           = $::ezproxy::params::service_enable,
   $http_proxy               = $::ezproxy::params::http_proxy,
   $https_proxy              = $::ezproxy::params::https_proxy,
+  $login_cookie_name        = $::ezproxy::params::login_cookie_name,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,9 +112,6 @@
 # [*https_proxy*]
 # String for forward proxy configuration for https proxy_hostname:port
 #
-# [*login_cookie_name*]
-# String for alternate cookie name for EZproxy session cookie
-#
 class ezproxy (
   $ezproxy_group            = $::ezproxy::params::ezproxy_group,
   $ezproxy_user             = $::ezproxy::params::ezproxy_user,
@@ -154,7 +151,6 @@ class ezproxy (
   $service_enable           = $::ezproxy::params::service_enable,
   $http_proxy               = $::ezproxy::params::http_proxy,
   $https_proxy              = $::ezproxy::params::https_proxy,
-  $login_cookie_name        = $::ezproxy::params::login_cookie_name,
 ) inherits ::ezproxy::params {
 
   validate_string($ezproxy_group)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class ezproxy::params {
   $service_status           = running
   $service_enable           = true
   $service_name             = 'ezproxy'
+  $log_user                 = false
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,8 @@ class ezproxy::params {
   $service_status           = running
   $service_enable           = true
   $service_name             = 'ezproxy'
+  $http_proxy               = undef
+  $https_proxy              = undef
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class ezproxy::params {
   $service_name             = 'ezproxy'
   $http_proxy               = undef
   $https_proxy              = undef
+  $login_cookie_name        = undef
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,6 @@ class ezproxy::params {
   $service_name             = 'ezproxy'
   $http_proxy               = undef
   $https_proxy              = undef
-  $login_cookie_name        = undef
 
   if $::architecture == 'amd64' {
     case $::operatingsystemrelease {

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -119,6 +119,20 @@ LogFilter <%= this_log_filter %>
 LogFile <%= @log_file %>
 LogFormat <%= @log_format %>
 
+## Enable forward proxying to allow EZproxy to access external resources
+## when behind a corporate firewall with no direct access allowed, see
+## https://www.oclc.org/support/services/ezproxy/documentation/cfg/proxy.en.html
+
+<% if @http_proxy -%>
+# Proxy host: port username: password 
+Proxy <%= @http_proxy %>
+<% end -%>
+
+<% if @https_proxy -%>
+# ProxySSL host: port username: password 
+ProxySSL <%= @https_proxy %>
+<% end -%>
+
 # **************************** Database Definitions *****************************************
 ##  See http://www.oclc.org/support/documentation/ezproxy/db/default.htm
 

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -103,7 +103,16 @@ Option SafariCookiePatch
 Audit Most
 AuditPurge 7
 Option StatusUser
+
+<% if @log_user -%>
+## If LogUser is required then LogSession should not also be included
+## if session identifiers are also required then a custom log format
+## should be specified that includes %{ezproxy-session}
+Option LogUser
+<% else -%>
 Option LogSession
+<% end -%>
+
 IntruderIPAttempts -interval=5 -expires=15 20
 IntruderUserAttempts -interval=5 -expires=15 10
 UsageLimit -enforce -interval=15 -expires=120 -MB=200 Global

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -97,13 +97,6 @@ MaxVirtualHosts <%= @max_vhosts %>
 ## (2006-03-10) or later, you can add add the following to work around the restriction.
 Option SafariCookiePatch
 
-<% if @login_cookie_name -%>
-## LoginCookieName specifies an alternate name for the EZproxy session cookie.
-## The default name for the EZproxy session cookie is ezproxy.
-
-# LoginCookieName name
-LoginCookieName <%= @login_cookie_name %>
-<% end -%>
 
 ##  Securing EZproxy == see: http://www.oclc.org/support/documentation/ezproxy/example/securing.htm
 

--- a/templates/config.txt.erb
+++ b/templates/config.txt.erb
@@ -97,6 +97,13 @@ MaxVirtualHosts <%= @max_vhosts %>
 ## (2006-03-10) or later, you can add add the following to work around the restriction.
 Option SafariCookiePatch
 
+<% if @login_cookie_name -%>
+## LoginCookieName specifies an alternate name for the EZproxy session cookie.
+## The default name for the EZproxy session cookie is ezproxy.
+
+# LoginCookieName name
+LoginCookieName <%= @login_cookie_name %>
+<% end -%>
 
 ##  Securing EZproxy == see: http://www.oclc.org/support/documentation/ezproxy/example/securing.htm
 

--- a/templates/stanza.erb
+++ b/templates/stanza.erb
@@ -1,12 +1,12 @@
-<% if @hide -%>
-T <%= @hide_flag %> <%= @name %>
-<% else -%>
-T <%= @name %>
-<% end -%>
 <% if @prepends -%>
 <% @prepends.each do |this_prepend| -%>
 <%= this_prepend %>
 <% end -%>
+<% end -%>
+<% if @hide -%>
+T <%= @hide_flag %> <%= @name %>
+<% else -%>
+T <%= @name %>
 <% end -%>
 <% if @urls -%>
 <% @urls.each do |this_url| -%>

--- a/templates/stanza.erb
+++ b/templates/stanza.erb
@@ -38,3 +38,4 @@ HJ <%= this_host_js %>
 <%= this_append %>
 <% end -%>
 <% end -%>
+


### PR DESCRIPTION
The stanza template places the prepends section below the Title of a stanza so it really isn't prepending it.

This swap the order of the elements of the stanza to move the prepend section to the top.

This is due to options you may specify apply to the next stanza, so if the options appear after the Title of the stanza it won't apply properly.

I didn't want to append the options to the preceding stanza.
